### PR TITLE
issue resolved for duplicate user

### DIFF
--- a/src/main/resources/db/changelog.master.xml
+++ b/src/main/resources/db/changelog.master.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
 
-  <includeAll path="db/changelog" />
-
-</databaseChangeLog>
+	 <include file="/changelog/db.changelog-1.0.xml" relativeToChangelogFile="true"/>
+	</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-1.0.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.0.xml
@@ -30,7 +30,7 @@
             <column name="PLACE" type="VARCHAR2(200)">
             </column>
 
-            <column name="CREATED_AT" type="TIMESTAMP(6)">
+            <column name="CREATED_AT" type="TIMESTAMP">
                 <constraints nullable="false"/>
             </column>
 
@@ -43,6 +43,10 @@
             ('User 1', 'A', 'user1@gmail.com', 'user1ABC', 'SomePlace', CURRENT_TIMESTAMP),
             ('User 1', 'A', 'user1@gmail.com', 'user1ABC', 'SomePlace', CURRENT_TIMESTAMP),
                 ('User 2', 'B', 'user2@gmail.com', 'user2ABC', 'SomePlace', CURRENT_TIMESTAMP);</sql>
+    </changeSet>
+    
+    <changeSet author="vikas godse" id="9999999-4">
+        <sql>delete from user where id= 1;</sql>
     </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
I observed that, 

- liquibase not able to read db.changelog, it is modified to specify changelog file.

- And Timestamp(6) is not a valid timestamp property so its modified as Timestamp.

- There is a duplicate user created in user table, So i removed the duplicate user by query written in changelog.xml file. 