### PR TITLE
Resolved duplicate entries in db

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-1.1.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.1.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  
+
+    <changeSet author="webonise" id="9999999-3">
+        <sql>
+        DELETE FROM user
+WHERE LOGIN_ID='user1@gmail.com';
+        INSERT INTO user (FIRST_NAME, LAST_NAME, LOGIN_ID, PASSWORD, PLACE, CREATED_AT)
+            VALUES
+            ('User 1', 'A', 'user1@gmail.com', 'user1ABC', 'SomePlace', CURRENT_TIMESTAMP);
+      
+                </sql>
+    </changeSet>
+
+</databaseChangeLog>

--- a/src/main/resources/db/changelog/db.changelog-1.2.xml
+++ b/src/main/resources/db/changelog/db.changelog-1.2.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                   http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.4.xsd">
+
+  
+
+    <changeSet author="webonise" id="9999999-3">
+        <addUniqueConstraint constraintName="unique_users_login_id" tableName="user" columnNames="LOGIN_ID" />
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
    Root cause:            
           - Duplicate entries for user1 in db

    Solution:
            - Add migration to remove duplicate entries for user1 and add
            only one entry again.

    Enhancement:
            - Login id field should be unique to block duplicate entries for
            email ids